### PR TITLE
Fix Create predicate when no Artifact

### DIFF
--- a/controllers/gitrepository_predicate.go
+++ b/controllers/gitrepository_predicate.go
@@ -29,6 +29,16 @@ type GitRepositoryRevisionChangePredicate struct {
 	predicate.Funcs
 }
 
+func (GitRepositoryRevisionChangePredicate) Create(e event.CreateEvent) bool {
+	src, ok := e.Object.(sourcev1.Source)
+
+	if !ok || src.GetArtifact() == nil {
+		return false
+	}
+
+	return true
+}
+
 func (GitRepositoryRevisionChangePredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil || e.ObjectNew == nil {
 		return false


### PR DESCRIPTION
The Create predicates was triggered at two point in times:
1. At the _startup_ of the service
2. When creating a new _source_

The issue is about the second part, when adding a new source. The issue related to that was a `nil` pointer exception while trying to get the Artifact. The fact that the artifact was not present mean that it simply crash in panic. To avoid this, I added a simple implementation for the Create predicate that looks for the Artifact (not nil). If it's there, then we want to run the code that follow, if not then simply say no (return false).

With just those lines it avoid the issues I encountered in the #16 .