### PR TITLE
A friendly typo fix

### DIFF
--- a/controllers/gitrepository_watcher.go
+++ b/controllers/gitrepository_watcher.go
@@ -116,7 +116,7 @@ func (r *GitRepositoryWatcher) fetchArtifact(ctx context.Context, repository sou
 
 	// check response
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("faild to download artifact, status: %s", resp.Status)
+		return "", fmt.Errorf("failed to download artifact, status: %s", resp.Status)
 	}
 
 	// extract


### PR DESCRIPTION
This fixes a silly typo in gitrepository_watcher.go I've been looking at for too long in our Slack channel.

Instead of "faild" it now says "failed".

Keep up the great work!

<3