### PR TITLE
fix(kubebuilder): correct group path for resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: source-reader
 rules:
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories
   verbs:
@@ -15,7 +15,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - source.fluxcd.io
+  - source.toolkit.fluxcd.io
   resources:
   - gitrepositories/status
   verbs:

--- a/controllers/gitrepository_watcher.go
+++ b/controllers/gitrepository_watcher.go
@@ -39,8 +39,8 @@ type GitRepositoryWatcher struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=gitrepositories,verbs=get;list;watch
-// +kubebuilder:rbac:groups=source.fluxcd.io,resources=gitrepositories/status,verbs=get
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories,verbs=get;list;watch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories/status,verbs=get
 
 func (r *GitRepositoryWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)


### PR DESCRIPTION
This bug was originally caused by https://github.com/fluxcd/source-controller/commit/8e1b213da5d31527432cced4fe9f93167fe0d535

This fix allows kubebuilder to create the correct RBAC