### PR TITLE
Fix broken Readme image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Example consumer of the GitOps Toolkit Source APIs.
 
-![](https://raw.githubusercontent.com/fluxcd/toolkit/main/docs/_files/source-controller.png)
+![](https://raw.githubusercontent.com/fluxcd/website/main/static/img/source-controller.png)
 
 ## Guides
 


### PR DESCRIPTION
Image broke when we moves files to the website. Quick simple fix

﻿Signed-off-by: Scott Rigby <scott@r6by.com>
