### PR TITLE
Publish signed multi-arch container images to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,17 +33,24 @@ jobs:
       - uses: docker/setup-buildx-action@v1
       - uses: sigstore/cosign-installer@main
       - uses: anchore/sbom-action/download-syft@v0
-      - name: Docker login
+      - name: Docker login ghcr.io
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: fluxcdbot
           password: ${{ secrets.GHCR_TOKEN }}
+      - name: Docker login docker.io
+        uses: docker/login-action@v1
+        with:
+          username: fluxcdbot
+          password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/fluxcd/${{ env.CONTROLLER }}
+          images: |
+          fluxcd/${{ env.CONTROLLER }}
+          ghcr.io/fluxcd/${{ env.CONTROLLER }}
           tags: |
             type=raw,value={{tag}}
       - name: Docker push
@@ -56,12 +63,13 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Docker sign
+      - name: Cosign sign ghcr.io
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
-          cosign sign ${{ steps.meta.outputs.tags }}
-      - uses: goreleaser/goreleaser-action@v2
+          cosign sign --recursive ghcr.io/fluxcd/${{ env.CONTROLLER }}:${GITHUB_REF/refs\/tags\//}
+      - name: GoReleaser publish signed SBOM
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ permissions:
   id-token: write # needed for keyless signing
   packages: write # needed for ghcr access
 
+env:
+  CONTROLLER: ${{ github.event.repository.name }}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,6 +31,43 @@ jobs:
             ${{ runner.os }}-go-
       - uses: sigstore/cosign-installer@main
       - uses: anchore/sbom-action/download-syft@v0
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: fluxcdbot
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION="${{ github.event.inputs.tag }}-${GITHUB_SHA::8}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF/refs\/tags\//}
+          fi
+          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Publish multi-arch container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          tags: |
+            ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
+      - name: Sign multi-arch container image
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,23 +29,24 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
       - uses: sigstore/cosign-installer@main
       - uses: anchore/sbom-action/download-syft@v0
-      - uses: docker/login-action@v1
+      - name: Docker login
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: fluxcdbot
           password: ${{ secrets.GHCR_TOKEN }}
-      - name: Prepare
-        id: prep
-        run: |
-          VERSION="${{ github.event.inputs.tag }}-${GITHUB_SHA::8}"
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF/refs\/tags\//}
-          fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
-      - name: Publish multi-arch container image
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/fluxcd/${{ env.CONTROLLER }}
+          tags: |
+            type=raw,value={{tag}}
+      - name: Docker push
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -53,21 +54,13 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          tags: |
-            ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
-      - name: Sign multi-arch container image
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Docker sign
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
-          cosign sign ghcr.io/fluxcd/${{ env.CONTROLLER }}:${{ steps.prep.outputs.VERSION }}
+          cosign sign ${{ steps.meta.outputs.tags }}
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,17 @@ builds:
 
 release:
   prerelease: auto
+  footer: |
+    ## Signed images
+    
+    Verify and pull the container image:
+
+    ```
+    COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/fluxcd/{{.ProjectName}}:{{.Tag}}
+    docker pull ghcr.io/fluxcd/{{.ProjectName}}:{{.Tag}}
+    ```
+    
+    Supported architectures: `linux/amd64`, `linux/arm64` and `linux/arm/v7`.
 
 changelog:
   use: github-native

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARD
 ### How to run the test suite
 
 Prerequisites:
-* go >= 1.16
-* kubebuilder >= 3.0
-* kustomize >= 4.0
+* go >= 1.17
+* docker >= 20.10
+* kustomize >= 4.4
 
 You can run the unit tests by simply doing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
-FROM golang:1.17-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine as builder
+
+# Copy the build utilities.
+COPY --from=xx / /
+
+ARG TARGETPLATFORM
 
 WORKDIR /workspace
+
+# copy api submodule
+COPY api/ api/
 
 # copy modules manifests
 COPY go.mod go.mod
@@ -14,7 +22,8 @@ COPY main.go main.go
 COPY controllers/ controllers/
 
 # build
-RUN CGO_ENABLED=0 go build -a -o source-watcher main.go
+ENV CGO_ENABLED=0
+RUN xx-go build -a -o source-watcher main.go
 
 FROM alpine:3.15
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= fluxcd/source-watcher:latest
 # Produce CRDs that work back to Kubernetes 1.16
 CRD_OPTIONS ?= crd:crdVersions=v1
 
@@ -10,6 +9,11 @@ GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif
+
+# Allows for defining additional Docker buildx arguments, e.g. '--push'.
+BUILD_ARGS ?=
+# Architectures to build images for.
+BUILD_PLATFORMS ?= linux/amd64
 
 # Architecture to use envtest with
 ENVTEST_ARCH ?= amd64
@@ -63,8 +67,12 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
-docker-build: test
-	docker build . -t ${IMG}
+docker-build:
+	docker buildx build \
+	--platform=$(BUILD_PLATFORMS) \
+	-t ${IMG} \
+	--load \
+	${BUILD_ARGS} .
 
 # Push the docker image
 docker-push:

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: manager
-          image: source-watcher
+          image: ghcr.io/fluxcd/source-watcher
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - deployment.yaml
 images:
-  - name: source-watcher
-    newName: source-watcher
-    newTag: v0.2.0
+  - name: ghcr.io/fluxcd/source-watcher
+    newName: ghcr.io/fluxcd/source-watcher
+    newTag: v0.10.0


### PR DESCRIPTION
Changes to release workflow:
- Build multi-arch image with Docker buildx and xx
- Push image to GHCR
- Sign image with Cosign and GitHub OIDC
