### PR TITLE
Add Kubernetes deployment to the release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: docker/setup-buildx-action@v1
       - uses: sigstore/cosign-installer@main
       - uses: anchore/sbom-action/download-syft@v0
+      - uses: fluxcd/pkg/actions/kustomize@main
       - name: Docker login ghcr.io
         uses: docker/login-action@v1
         with:
@@ -68,6 +69,9 @@ jobs:
           COSIGN_EXPERIMENTAL: 1
         run: |
           cosign sign --recursive ghcr.io/fluxcd/${{ env.CONTROLLER }}:${GITHUB_REF/refs\/tags\//}
+      - name: Generate deployment manifest
+        run: |
+          IMG=ghcr.io/fluxcd/${{ env.CONTROLLER }}:${GITHUB_REF/refs\/tags\//} make manifests-release
       - name: GoReleaser publish signed SBOM
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Local build output dir
 bin/
 testbin/
+build/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,8 @@ release:
     ```
     
     Supported architectures: `linux/amd64`, `linux/arm64` and `linux/arm/v7`.
+  extra_files:
+    - glob: build/source-watcher.deployment.yaml
 
 changelog:
   use: github-native

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ docker-build:
 docker-push:
 	docker push ${IMG}
 
+manifests-release:
+	mkdir -p ./build
+	mkdir -p config/release-tmp && cp config/release/* config/release-tmp
+	cd config/release-tmp && kustomize edit set image fluxcd/source-watcher=${IMG}
+	kustomize build config/release-tmp > ./build/source-watcher.deployment.yaml
+	rm -rf config/release-tmp
+
 # Find or download controller-gen
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -4,6 +4,6 @@ namespace: source-system
 resources:
   - ../rbac
   - ../manager
-  - github.com/fluxcd/source-controller/config//crd?ref=v0.2.0
-  - github.com/fluxcd/source-controller/config//manager?ref=v0.2.0
+  - github.com/fluxcd/source-controller/config//crd?ref=main
+  - github.com/fluxcd/source-controller/config//manager?ref=main
   - namespace.yaml

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: manager
-          image: ghcr.io/fluxcd/source-watcher
+          image: fluxcd/source-watcher
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,7 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deployment.yaml
-images:
-  - name: ghcr.io/fluxcd/source-watcher
-    newName: ghcr.io/fluxcd/source-watcher
-    newTag: v0.10.0

--- a/config/release-tmp/kustomization.yaml
+++ b/config/release-tmp/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+- ../manager
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: source-watcher
+  spec:
+    template:
+      spec:
+        serviceAccountName: source-controller
+images:
+- name: fluxcd/source-watcher
+  newName: ghcr.io/fluxcd/source-watcher
+  newTag: v0.10.0

--- a/config/release/kustomization.yaml
+++ b/config/release/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - ../manager
+patchesStrategicMerge:
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: source-watcher
+    spec:
+      template:
+        spec:
+          serviceAccountName: source-controller


### PR DESCRIPTION
Release workflow changes:
- Add release Kustomize overlay
    - Set source-watcher namespace to `flux-system`
    - Set source-watcher service account to `source-controller` 
- Generate Kubernetes deployment manifest for the release version
- Publish deployment manifest with GoReleaser