### PR TITLE
Fix warning for Dockerfile casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG XX_VERSION=1.4.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 # Copy the build utilities.
 COPY --from=xx / /


### PR DESCRIPTION
Hi folks, I'm working on building a Flux controller for [Radius](https://github.com/radius-project/radius) and this template has been super useful! Thanks for authoring.

I ran `make docker-build` today and I got this warning, thought that I'd fix it. Feel free to close if this is unnecessary to change :)

<img width="635" alt="image" src="https://github.com/user-attachments/assets/0e8dfb69-a49a-4cc0-adc9-6a943ae62341">
