### PR TITLE
Conform with GitOps Toolkit standards

### DIFF
--- a/api/v1beta1/artifactgenerator_types.go
+++ b/api/v1beta1/artifactgenerator_types.go
@@ -22,7 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fluxcd/pkg/apis/meta"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
 )
 
 const (
@@ -157,7 +157,7 @@ type CopyOperation struct {
 
 // ArtifactGeneratorStatus defines the observed state of ArtifactGenerator.
 type ArtifactGeneratorStatus struct {
-	meta.ReconcileRequestStatus `json:",inline"`
+	gotkmeta.ReconcileRequestStatus `json:",inline"`
 
 	// Conditions holds the conditions for the ArtifactGenerator.
 	// +optional

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -48,6 +48,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           args:
+            - --watch-all-namespaces
             - --log-level=info
             - --log-encoding=json
             - --enable-leader-election

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ with advanced source composition and decomposition patterns.
 | `--artifact-retention-ttl`            | duration      | The duration of time that artifacts from previous reconciliations will be kept in storage before being garbage collected. (default 1m0s)                                                 |
 | `--concurrent`                        | int           | The number of concurrent reconciles per controller. (default 10)                                                                                                                         |
 | `--enable-leader-election`            | boolean       | Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.                                                                    |
+| `--events-addr`                       | string        | The address of the events receiver.                                                                                                                                                      |
 | `--health-addr`                       | string        | The address the health endpoint binds to. (default ":9440")                                                                                                                              |
 | `--http-retry`                        | int           | The maximum number of retries when failing to fetch artifacts over HTTP. (default 9)                                                                                                     |
 | `--interval-jitter-percentage`        | uint8         | Percentage of jitter to apply to interval durations. A value of 10 will apply a jitter of +/-10% to the interval duration. It cannot be negative, and must be less than 100. (default 5) |
@@ -39,6 +40,7 @@ with advanced source composition and decomposition patterns.
 | `--storage-addr`                      | string        | The address the static file server binds to. (default ":9090")                                                                                                                           |
 | `--storage-adv-addr`                  | string        | The advertised address of the static file server.                                                                                                                                        |
 | `--storage-path`                      | string        | The local storage path. (default "/data")                                                                                                                                                |
+| `--watch-all-namespaces`              | boolean       | Watch for resources in all namespaces, if set to false it will only watch the runtime namespace. (default true)                                                                          |
 | `--feature-gates`                     | mapStringBool | A comma separated list of key=value pairs defining the state of experimental features.                                                                                                   |
 
 ### Feature Gates

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -28,8 +28,8 @@ import (
 	"golang.org/x/mod/sumdb/dirhash"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/artifact/storage"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	gotkstorage "github.com/fluxcd/pkg/artifact/storage"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
@@ -38,11 +38,11 @@ import (
 // ArtifactBuilder is responsible for building and storing artifacts
 // based on a given specification and source files.
 type ArtifactBuilder struct {
-	Storage *storage.Storage
+	Storage *gotkstorage.Storage
 }
 
 // New creates a new ArtifactBuilder with the given storage backend.
-func New(storage *storage.Storage) *ArtifactBuilder {
+func New(storage *gotkstorage.Storage) *ArtifactBuilder {
 	return &ArtifactBuilder{
 		Storage: storage,
 	}
@@ -58,7 +58,7 @@ func (r *ArtifactBuilder) Build(ctx context.Context,
 	spec *swapi.OutputArtifact,
 	sources map[string]string,
 	namespace string,
-	workspace string) (*meta.Artifact, error) {
+	workspace string) (*gotkmeta.Artifact, error) {
 	// Create a dir to stage the artifact files.
 	stagingDir := filepath.Join(workspace, spec.Name)
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
@@ -100,7 +100,7 @@ func (r *ArtifactBuilder) Build(ctx context.Context,
 	defer unlock()
 
 	// Create the artifact tarball from the staging dir.
-	if err := r.Storage.Archive(&artifact, stagingDir, storage.SourceIgnoreFilter(nil, nil)); err != nil {
+	if err := r.Storage.Archive(&artifact, stagingDir, gotkstorage.SourceIgnoreFilter(nil, nil)); err != nil {
 		return nil, fmt.Errorf("failed to create artifact: %w", err)
 	}
 

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -23,8 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/fluxcd/pkg/apis/meta"
 	. "github.com/onsi/gomega"
+
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 )
@@ -33,7 +34,7 @@ func TestBuild(t *testing.T) {
 	tests := []struct {
 		name         string
 		setupFunc    func(t *testing.T) (*swapi.OutputArtifact, map[string]string, string)
-		validateFunc func(t *testing.T, artifact *meta.Artifact, stagingDir string)
+		validateFunc func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string)
 	}{
 		{
 			name: "build artifact with single file copy",
@@ -61,7 +62,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "config.yaml"): "apiVersion: v1\nkind: ConfigMap",
 				}
@@ -101,7 +102,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedRevision := fmt.Sprintf("latest@%s", artifact.Digest)
 				if artifact.Revision != expectedRevision {
 					t.Errorf("Expected revision '%s', got '%s'", expectedRevision, artifact.Revision)
@@ -142,7 +143,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "manifests", "deployment.yaml"): "apiVersion: v1",
 					filepath.Join(stagingDir, "manifests", "service.yaml"):    "apiVersion: v1",
@@ -178,7 +179,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "root.yaml"):             "root: content",
 					filepath.Join(stagingDir, "subdir", "nested.yaml"): "nested: content",
@@ -213,7 +214,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "root.yaml"):             "root: content",
 					filepath.Join(stagingDir, "subdir", "nested.yaml"): "nested: content",
@@ -258,7 +259,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					// app.yaml should be overwritten by source2
 					filepath.Join(stagingDir, "config", "app.yaml"): "source2: app",
@@ -299,7 +300,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				// Since destination always exists, cp creates config as subdirectory
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "dest", "config", "app.yaml"): "app: config",
@@ -337,7 +338,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				// Should create dest/config/ with contents
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "dest", "config", "app.yaml"): "app: config",
@@ -373,7 +374,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "dest", "config.yaml"): "a: test",
 				}
@@ -411,7 +412,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "dest", "app.yaml"):          "app: config",
 					filepath.Join(stagingDir, "dest", "subdir", "db.yaml"): "db: config",
@@ -456,7 +457,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "Chart.yaml"):             "name: podinfo",
 					filepath.Join(stagingDir, "podinfo", "values.yaml"): "env: production",
@@ -495,7 +496,7 @@ func TestBuild(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				expectedFiles := map[string]string{
 					filepath.Join(stagingDir, "subdir", "file1.txt"): "content1",
 					filepath.Join(stagingDir, "subdir", "file2.txt"): "content2",
@@ -693,7 +694,7 @@ func TestBuildWithExcludes(t *testing.T) {
 	tests := []struct {
 		name          string
 		setupFunc     func(t *testing.T) (*swapi.OutputArtifact, map[string]string, string)
-		validateFunc  func(t *testing.T, artifact *meta.Artifact, stagingDir string)
+		validateFunc  func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string)
 		expectError   bool
 		expectedError string
 	}{
@@ -730,7 +731,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				g := NewWithT(t)
 				artifactDir := filepath.Join(stagingDir, "test-artifact")
 
@@ -779,7 +780,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				g := NewWithT(t)
 				artifactDir := filepath.Join(stagingDir, "test-artifact")
 
@@ -836,7 +837,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				g := NewWithT(t)
 				artifactDir := filepath.Join(stagingDir, "test-artifact")
 
@@ -888,7 +889,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				g := NewWithT(t)
 				artifactDir := filepath.Join(stagingDir, "test-artifact")
 
@@ -932,7 +933,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				g := NewWithT(t)
 				artifactDir := filepath.Join(stagingDir, "test-artifact")
 
@@ -975,7 +976,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				// This test expects an error, so validateFunc won't be called
 			},
 			expectError:   true,
@@ -1006,7 +1007,7 @@ func TestBuildWithExcludes(t *testing.T) {
 
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, stagingDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, stagingDir string) {
 				// This test expects an error, so validateFunc won't be called
 			},
 			expectError:   true,

--- a/internal/builder/merge_test.go
+++ b/internal/builder/merge_test.go
@@ -24,7 +24,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/fluxcd/pkg/apis/meta"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 )
@@ -33,7 +33,7 @@ func TestBuild_YAMLMergeStrategy(t *testing.T) {
 	tests := []struct {
 		name          string
 		setupFunc     func(t *testing.T) (*swapi.OutputArtifact, map[string]string, string)
-		validateFunc  func(t *testing.T, artifact *meta.Artifact, workspaceDir string)
+		validateFunc  func(t *testing.T, artifact *gotkmeta.Artifact, workspaceDir string)
 		expectedError string
 	}{
 		{
@@ -88,7 +88,7 @@ env: production # This should add a new top-level field
 				}
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, workspaceDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, workspaceDir string) {
 				g := NewWithT(t)
 				g.Expect(artifact).ToNot(BeNil())
 
@@ -150,7 +150,7 @@ env: production
 				}
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, workspaceDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, workspaceDir string) {
 				g := NewWithT(t)
 				g.Expect(artifact).ToNot(BeNil())
 
@@ -192,7 +192,7 @@ c:
 				sources := map[string]string{"source": sourceDir}
 				return spec, sources, workspaceDir
 			},
-			validateFunc: func(t *testing.T, artifact *meta.Artifact, workspaceDir string) {
+			validateFunc: func(t *testing.T, artifact *gotkmeta.Artifact, workspaceDir string) {
 				g := NewWithT(t)
 				g.Expect(artifact).ToNot(BeNil())
 

--- a/internal/builder/suite_test.go
+++ b/internal/builder/suite_test.go
@@ -23,37 +23,37 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/artifact/config"
-	"github.com/fluxcd/pkg/artifact/digest"
-	"github.com/fluxcd/pkg/artifact/storage"
-	"github.com/fluxcd/pkg/tar"
-	"github.com/fluxcd/pkg/testserver"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	gotkconfig "github.com/fluxcd/pkg/artifact/config"
+	gotkdigest "github.com/fluxcd/pkg/artifact/digest"
+	gotkstorage "github.com/fluxcd/pkg/artifact/storage"
+	gotktar "github.com/fluxcd/pkg/tar"
+	gotktestsrv "github.com/fluxcd/pkg/testserver"
 
 	"github.com/fluxcd/source-watcher/internal/builder"
 )
 
 var (
 	testBuilder *builder.ArtifactBuilder
-	testStorage *storage.Storage
-	testServer  *testserver.ArtifactServer
+	testStorage *gotkstorage.Storage
+	testServer  *gotktestsrv.ArtifactServer
 )
 
 func TestMain(m *testing.M) {
 	var err error
-	testServer, err = testserver.NewTempArtifactServer()
+	testServer, err = gotktestsrv.NewTempArtifactServer()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create a temporary storage server: %v", err))
 	}
 	testServer.Start()
 
-	testStorage, err = storage.New(&config.Options{
+	testStorage, err = gotkstorage.New(&gotkconfig.Options{
 		ArtifactRetentionRecords: 2,
 
 		StoragePath:          testServer.Root(),
 		StorageAddress:       testServer.URL(),
 		StorageAdvAddress:    testServer.URL(),
-		ArtifactDigestAlgo:   digest.Canonical.String(),
+		ArtifactDigestAlgo:   gotkdigest.Canonical.String(),
 		ArtifactRetentionTTL: time.Hour,
 	})
 	if err != nil {
@@ -75,8 +75,8 @@ func TestMain(m *testing.M) {
 // verifyContents extracts and verifies the contents of a tar.gz artifact
 // It takes the expected files from the staging directory and verifies they exist in the tar.gz
 func verifyContents(t *testing.T,
-	testStorage *storage.Storage,
-	artifact *meta.Artifact,
+	testStorage *gotkstorage.Storage,
+	artifact *gotkmeta.Artifact,
 	stagingDir string,
 	expectedFiles map[string]string) {
 	t.Helper()
@@ -95,7 +95,7 @@ func verifyContents(t *testing.T,
 	defer file.Close()
 
 	// Extract the tar.gz file
-	if err := tar.Untar(file, extractDir, tar.WithMaxUntarSize(-1)); err != nil {
+	if err := gotktar.Untar(file, extractDir, gotktar.WithMaxUntarSize(-1)); err != nil {
 		t.Fatalf("Failed to extract tar.gz %s: %v", artifactPath, err)
 	}
 

--- a/internal/controller/artifactgenerator_drift.go
+++ b/internal/controller/artifactgenerator_drift.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/artifact/storage"
-	"github.com/fluxcd/pkg/runtime/conditions"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	gotkstorage "github.com/fluxcd/pkg/artifact/storage"
+	gotkconditions "github.com/fluxcd/pkg/runtime/conditions"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 )
@@ -48,14 +49,14 @@ func (r *ArtifactGeneratorReconciler) detectDrift(ctx context.Context,
 	// Setup logger on debug level.
 	log := ctrl.LoggerFrom(ctx).V(1)
 
-	if conditions.IsFalse(obj, meta.ReadyCondition) {
+	if gotkconditions.IsFalse(obj, gotkmeta.ReadyCondition) {
 		log.Info("Drift detected, previous reconciliation failed")
 		return true, "NotReady"
 	}
 
-	if obj.GetGeneration() != conditions.GetObservedGeneration(obj, meta.ReadyCondition) {
+	if obj.GetGeneration() != gotkconditions.GetObservedGeneration(obj, gotkmeta.ReadyCondition) {
 		log.Info("Drift detected, generation has changed",
-			"old", conditions.GetObservedGeneration(obj, meta.ReadyCondition),
+			"old", gotkconditions.GetObservedGeneration(obj, gotkmeta.ReadyCondition),
 			"new", obj.GetGeneration())
 		return true, "GenerationChanged"
 	}
@@ -75,8 +76,8 @@ func (r *ArtifactGeneratorReconciler) detectDrift(ctx context.Context,
 	}
 
 	for _, eaRef := range obj.Status.Inventory {
-		storagePath := storage.ArtifactPath(sourcev1.ExternalArtifactKind, eaRef.Namespace, eaRef.Name, eaRef.Filename)
-		artifact := meta.Artifact{
+		storagePath := gotkstorage.ArtifactPath(sourcev1.ExternalArtifactKind, eaRef.Namespace, eaRef.Name, eaRef.Filename)
+		artifact := gotkmeta.Artifact{
 			Digest: eaRef.Digest,
 			Path:   storagePath,
 		}

--- a/internal/controller/artifactgenerator_drift_test.go
+++ b/internal/controller/artifactgenerator_drift_test.go
@@ -22,10 +22,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 	"github.com/fluxcd/source-watcher/internal/builder"
@@ -105,9 +106,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							Reason:             meta.SucceededReason,
+							Reason:             gotkmeta.SucceededReason,
 							ObservedGeneration: 1,
 						},
 					},
@@ -137,9 +138,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionFalse, // Not ready
-							Reason:             meta.BuildFailedReason,
+							Reason:             gotkmeta.BuildFailedReason,
 							ObservedGeneration: 1,
 						},
 					},
@@ -161,9 +162,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							Reason:             meta.SucceededReason,
+							Reason:             gotkmeta.SucceededReason,
 							ObservedGeneration: 1, // Different from Generation
 						},
 					},
@@ -185,9 +186,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							Reason:             meta.SucceededReason,
+							Reason:             gotkmeta.SucceededReason,
 							ObservedGeneration: 1,
 						},
 					},
@@ -215,9 +216,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							Reason:             meta.SucceededReason,
+							Reason:             gotkmeta.SucceededReason,
 							ObservedGeneration: 1,
 						},
 					},
@@ -251,9 +252,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							Reason:             meta.SucceededReason,
+							Reason:             gotkmeta.SucceededReason,
 							ObservedGeneration: 1,
 						},
 					},
@@ -299,9 +300,9 @@ func TestArtifactGeneratorReconciler_DetectDrift(t *testing.T) {
 				Status: swapi.ArtifactGeneratorStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               meta.ReadyCondition,
+							Type:               gotkmeta.ReadyCondition,
 							Status:             metav1.ConditionTrue,
-							Reason:             meta.SucceededReason,
+							Reason:             gotkmeta.SucceededReason,
 							ObservedGeneration: 1,
 						},
 					},

--- a/internal/controller/artifactgenerator_finalize.go
+++ b/internal/controller/artifactgenerator_finalize.go
@@ -26,9 +26,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/artifact/storage"
-	"github.com/fluxcd/pkg/runtime/conditions"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	gotkstorage "github.com/fluxcd/pkg/artifact/storage"
+	gotkconditions "github.com/fluxcd/pkg/runtime/conditions"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
@@ -58,8 +58,8 @@ func (r *ArtifactGeneratorReconciler) finalizeExternalArtifacts(ctx context.Cont
 
 	for _, eaRef := range refs {
 		// Delete from storage.
-		storagePath := storage.ArtifactPath(sourcev1.ExternalArtifactKind, eaRef.Namespace, eaRef.Name, "*")
-		rmDir, err := r.Storage.RemoveAll(meta.Artifact{Path: storagePath})
+		storagePath := gotkstorage.ArtifactPath(sourcev1.ExternalArtifactKind, eaRef.Namespace, eaRef.Name, "*")
+		rmDir, err := r.Storage.RemoveAll(gotkmeta.Artifact{Path: storagePath})
 		if err != nil {
 			log.Error(err, "Failed to delete artifact from storage", "path", storagePath)
 		} else if rmDir != "" {
@@ -87,17 +87,17 @@ func (r *ArtifactGeneratorReconciler) finalizeExternalArtifacts(ctx context.Cont
 func (r *ArtifactGeneratorReconciler) addFinalizer(obj *swapi.ArtifactGenerator) (ctrl.Result, error) {
 	controllerutil.AddFinalizer(obj, swapi.Finalizer)
 	if obj.IsDisabled() {
-		conditions.MarkTrue(obj,
-			meta.ReadyCondition,
+		gotkconditions.MarkTrue(obj,
+			gotkmeta.ReadyCondition,
 			swapi.ReconciliationDisabledReason,
 			"%s", msgInitSuspended)
 	} else {
-		conditions.MarkUnknown(obj,
-			meta.ReadyCondition,
-			meta.ProgressingReason,
+		gotkconditions.MarkUnknown(obj,
+			gotkmeta.ReadyCondition,
+			gotkmeta.ProgressingReason,
 			"%s", msgInProgress)
-		conditions.MarkReconciling(obj,
-			meta.ProgressingReason,
+		gotkconditions.MarkReconciling(obj,
+			gotkmeta.ProgressingReason,
 			"%s", msgInProgress)
 	}
 

--- a/internal/controller/artifactgenerator_finalize_test.go
+++ b/internal/controller/artifactgenerator_finalize_test.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/runtime/conditions"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	gotkconditions "github.com/fluxcd/pkg/runtime/conditions"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 )
@@ -64,8 +64,8 @@ func TestResourceSetReconciler_Finalize(t *testing.T) {
 	g.Expect(obj.Finalizers).To(ContainElement(swapi.Finalizer))
 
 	// Verify the object is in reconciling state
-	g.Expect(conditions.IsReconciling(obj)).To(BeTrue())
-	g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(meta.ProgressingReason))
+	g.Expect(gotkconditions.IsReconciling(obj)).To(BeTrue())
+	g.Expect(gotkconditions.GetReason(obj, gotkmeta.ReadyCondition)).To(Equal(gotkmeta.ProgressingReason))
 
 	// Delete the object to trigger finalization
 	err = testClient.Delete(ctx, obj)
@@ -129,8 +129,8 @@ func TestResourceSetReconciler_Finalize_Disabled(t *testing.T) {
 	// Verify the object is marked as disabled
 	err = testClient.Get(ctx, objKey, obj)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(conditions.IsTrue(obj, meta.ReadyCondition)).To(BeTrue())
-	g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(swapi.ReconciliationDisabledReason))
+	g.Expect(gotkconditions.IsTrue(obj, gotkmeta.ReadyCondition)).To(BeTrue())
+	g.Expect(gotkconditions.GetReason(obj, gotkmeta.ReadyCondition)).To(Equal(swapi.ReconciliationDisabledReason))
 
 	// Delete the object to trigger finalization
 	err = testClient.Delete(ctx, obj)

--- a/internal/controller/artifactgenerator_manager.go
+++ b/internal/controller/artifactgenerator_manager.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/fluxcd/pkg/runtime/predicates"
+	gotkpredicates "github.com/fluxcd/pkg/runtime/predicates"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
@@ -62,7 +62,7 @@ func (r *ArtifactGeneratorReconciler) SetupWithManager(ctx context.Context,
 			builder.WithPredicates(
 				predicate.Or(
 					predicate.GenerationChangedPredicate{},
-					predicates.ReconcileRequestedPredicate{},
+					gotkpredicates.ReconcileRequestedPredicate{},
 				),
 			)).
 		Watches(

--- a/internal/controller/artifactgenerator_validation_test.go
+++ b/internal/controller/artifactgenerator_validation_test.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fluxcd/pkg/runtime/conditions"
+	gotkmeta "github.com/fluxcd/pkg/apis/meta"
+	gotkconditions "github.com/fluxcd/pkg/runtime/conditions"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 )
@@ -132,8 +132,8 @@ func TestResourceSetReconciler_specValidation(t *testing.T) {
 			// Verify the object is stalled with validation failed reason
 			err = testClient.Get(ctx, objKey, obj)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(conditions.IsStalled(obj)).To(BeTrue())
-			g.Expect(conditions.GetReason(obj, meta.ReadyCondition)).To(Equal(tt.expectedReason))
+			g.Expect(gotkconditions.IsStalled(obj)).To(BeTrue())
+			g.Expect(gotkconditions.GetReason(obj, gotkmeta.ReadyCondition)).To(Equal(tt.expectedReason))
 
 			// Verify event was recorded
 			events := getEvents(obj.Name, obj.Namespace)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,10 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/fluxcd/pkg/artifact/config"
-	"github.com/fluxcd/pkg/artifact/digest"
-	"github.com/fluxcd/pkg/artifact/storage"
-	"github.com/fluxcd/pkg/runtime/testenv"
+	gotkconfig "github.com/fluxcd/pkg/artifact/config"
+	gotkdigest "github.com/fluxcd/pkg/artifact/digest"
+	gotkstorage "github.com/fluxcd/pkg/artifact/storage"
+	gotktestenv "github.com/fluxcd/pkg/runtime/testenv"
 	"github.com/fluxcd/pkg/testserver"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
@@ -46,9 +46,9 @@ import (
 var (
 	controllerName   = "source-watcher"
 	timeout          = 10 * time.Second
-	testStorage      *storage.Storage
+	testStorage      *gotkstorage.Storage
 	testServer       *testserver.ArtifactServer
-	testEnv          *testenv.Environment
+	testEnv          *gotktestenv.Environment
 	testClient       client.Client
 	testCtx          = ctrl.SetupSignalHandler()
 	retentionTTL     = 2 * time.Second
@@ -66,11 +66,11 @@ func NewTestScheme() *runtime.Scheme {
 
 func TestMain(m *testing.M) {
 	var err error
-	testEnv = testenv.New(
-		testenv.WithCRDPath(
+	testEnv = gotktestenv.New(
+		gotktestenv.WithCRDPath(
 			filepath.Join("..", "..", "config", "crd", "bases"),
 		),
-		testenv.WithScheme(NewTestScheme()),
+		gotktestenv.WithScheme(NewTestScheme()),
 	)
 
 	testServer, err = testserver.NewTempArtifactServer()
@@ -112,16 +112,16 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func newTestStorage(s *testserver.HTTPServer) (*storage.Storage, error) {
-	opts := &config.Options{
+func newTestStorage(s *testserver.HTTPServer) (*gotkstorage.Storage, error) {
+	opts := &gotkconfig.Options{
 		StoragePath:              s.Root(),
 		StorageAddress:           s.URL(),
 		StorageAdvAddress:        s.URL(),
 		ArtifactRetentionTTL:     retentionTTL,
 		ArtifactRetentionRecords: retentionRecords,
-		ArtifactDigestAlgo:       digest.Canonical.String(),
+		ArtifactDigestAlgo:       gotkdigest.Canonical.String(),
 	}
-	st, err := storage.New(opts)
+	st, err := gotkstorage.New(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller_test/suite_test.go
+++ b/internal/controller_test/suite_test.go
@@ -23,17 +23,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fluxcd/pkg/artifact/config"
-	"github.com/fluxcd/pkg/artifact/digest"
-	"github.com/fluxcd/pkg/artifact/storage"
-	"github.com/fluxcd/pkg/runtime/testenv"
-	"github.com/fluxcd/pkg/testserver"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gotkconfig "github.com/fluxcd/pkg/artifact/config"
+	gotkdigest "github.com/fluxcd/pkg/artifact/digest"
+	gotkstorage "github.com/fluxcd/pkg/artifact/storage"
+	gotktestenv "github.com/fluxcd/pkg/runtime/testenv"
+	gotktestsrv "github.com/fluxcd/pkg/testserver"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	swapi "github.com/fluxcd/source-watcher/api/v1beta1"
 	"github.com/fluxcd/source-watcher/internal/controller"
@@ -43,9 +44,9 @@ import (
 var (
 	controllerName   = "source-watcher"
 	timeout          = 15 * time.Second
-	testStorage      *storage.Storage
-	testServer       *testserver.ArtifactServer
-	testEnv          *testenv.Environment
+	testStorage      *gotkstorage.Storage
+	testServer       *gotktestsrv.ArtifactServer
+	testEnv          *gotktestenv.Environment
 	testClient       client.Client
 	testCtx          = ctrl.SetupSignalHandler()
 	retentionTTL     = 2 * time.Second
@@ -63,14 +64,14 @@ func NewTestScheme() *runtime.Scheme {
 
 func TestMain(m *testing.M) {
 	var err error
-	testEnv = testenv.New(
-		testenv.WithCRDPath(
+	testEnv = gotktestenv.New(
+		gotktestenv.WithCRDPath(
 			filepath.Join("..", "..", "config", "crd", "bases"),
 		),
-		testenv.WithScheme(NewTestScheme()),
+		gotktestenv.WithScheme(NewTestScheme()),
 	)
 
-	testServer, err = testserver.NewTempArtifactServer()
+	testServer, err = gotktestsrv.NewTempArtifactServer()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create a temporary storage server: %v", err))
 	}
@@ -113,16 +114,16 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func newTestStorage(s *testserver.HTTPServer) (*storage.Storage, error) {
-	opts := &config.Options{
+func newTestStorage(s *gotktestsrv.HTTPServer) (*gotkstorage.Storage, error) {
+	opts := &gotkconfig.Options{
 		StoragePath:              s.Root(),
 		StorageAddress:           s.URL(),
 		StorageAdvAddress:        s.URL(),
 		ArtifactRetentionTTL:     retentionTTL,
 		ArtifactRetentionRecords: retentionRecords,
-		ArtifactDigestAlgo:       digest.Canonical.String(),
+		ArtifactDigestAlgo:       gotkdigest.Canonical.String(),
 	}
-	st, err := storage.New(opts)
+	st, err := gotkstorage.New(opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes:
- Add controller flags required for conforming with the GitOps Toolkit standards
- Prefix imports with `gotk` to denote which modules are part of the GitOps Toolkit

Part of: https://github.com/fluxcd/flux2/issues/5514