### PR TITLE
ci: Add `sync-labels` workflow and backport label

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: "gomod"
+    labels: ["dependencies"]
     directory: "/"
     schedule:
       interval: "monthly"
@@ -20,6 +21,7 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
   - package-ecosystem: "github-actions"
+    labels: ["dependencies"]
     directory: "/"
     schedule:
       interval: "monthly"
@@ -28,6 +30,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
+    labels: ["dependencies"]
     directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,13 @@
+# Configuration file to declaratively configure labels
+# Ref: https://github.com/EndBug/label-sync#Config-files
+
+- name: area/generator
+  description: Artifact generation related issues and pull requests
+  color: '#00b140'
+- name: area/storage
+  description: Artifact storage related issues and pull requests
+  color: '#4b0082'
+- name: backport:release/v2.0.x
+  description: To be backported to release/v2.0.x
+  color: '#ffd700'
+

--- a/.github/workflows/labels-sync.yaml
+++ b/.github/workflows/labels-sync.yaml
@@ -1,0 +1,14 @@
+name: sync-labels
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yaml
+jobs:
+  sync-labels:
+    permissions:
+      issues: write
+      contents: read
+    uses: fluxcd/gha-workflows/.github/workflows/labels-sync.yaml@v0.0.1


### PR DESCRIPTION
Add `sync-labels` workflow from https://github.com/fluxcd/gha-workflows