### PR TITLE
Add `securityContext.fsGroup` to deployment

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 1337
       containers:
         - name: manager
           image: fluxcd/source-watcher


### PR DESCRIPTION
All Flux controllers have `fsGroup: 1337`, this was missing from source-watcher deployment spec.