### PR TITLE
Add categories to the ArtifactGenerator CRD

### DIFF
--- a/api/v1beta1/artifactgenerator_types.go
+++ b/api/v1beta1/artifactgenerator_types.go
@@ -271,7 +271,7 @@ func (in *ArtifactGenerator) HasArtifactInInventory(name, namespace, digest stri
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=ag
+// +kubebuilder:resource:shortName=ag,categories=all;fluxcd;fluxcd-sources
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""

--- a/config/crd/bases/source.extensions.fluxcd.io_artifactgenerators.yaml
+++ b/config/crd/bases/source.extensions.fluxcd.io_artifactgenerators.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: source.extensions.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-sources
     kind: ArtifactGenerator
     listKind: ArtifactGeneratorList
     plural: artifactgenerators


### PR DESCRIPTION
This adds the standard Flux resource categories to the ArtifactGenerator CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd          # all Flux resources
kubectl get fluxcd-sources   # all resources in this category
kubectl get all             # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-sources
```

The CRDs were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
