### PR TITLE
Add backport:release/v2.2.x label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -13,4 +13,7 @@
 - name: backport:release/v2.1.x
   description: To be backported to release/v2.1.x
   color: '#ffd700'
+- name: backport:release/v2.2.x
+  description: To be backported to release/v2.2.x
+  color: '#ffd700'
 


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5942