### PR TITLE
Add optional field to CopyOperation

### DIFF
--- a/api/v1beta1/artifactgenerator_types.go
+++ b/api/v1beta1/artifactgenerator_types.go
@@ -191,6 +191,13 @@ type CopyOperation struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Overwrite;Merge;Extract
 	Strategy string `json:"strategy,omitempty"`
+
+	// Optional, when set to true, allows the copy operation to silently
+	// skip when the source path or glob pattern matches no files.
+	// When false (default), the reconciliation fails with an error if
+	// no files are matched.
+	// +optional
+	Optional bool `json:"optional,omitempty"`
 }
 
 // ArtifactGeneratorStatus defines the observed state of ArtifactGenerator.

--- a/config/crd/bases/source.extensions.fluxcd.io_artifactgenerators.yaml
+++ b/config/crd/bases/source.extensions.fluxcd.io_artifactgenerators.yaml
@@ -90,6 +90,13 @@ spec:
                             minLength: 1
                             pattern: ^@([a-z0-9]([a-z0-9_-]*[a-z0-9])?)/(.*)$
                             type: string
+                          optional:
+                            description: |-
+                              Optional, when set to true, allows the copy operation to silently
+                              skip when the source path or glob pattern matches no files.
+                              When false (default), the reconciliation fails with an error if
+                              no files are matched.
+                            type: boolean
                           strategy:
                             description: |-
                               Strategy specifies the copy strategy to use.

--- a/docs/spec/v1beta1/artifactgenerators.md
+++ b/docs/spec/v1beta1/artifactgenerators.md
@@ -322,6 +322,9 @@ Each copy operation specifies how to copy files from sources into the generated 
   file name at any depth.
 - `strategy` (optional): Defines how to handle files during copy operations:
   `Overwrite` (default), `Merge` (for YAML files), or `Extract` (for tarball archives).
+- `optional` (optional): When set to `true`, the copy operation silently
+  skips if the source path or glob pattern matches no files. Defaults to `false`,
+  which causes the reconciliation to fail with an error on missing sources.
 
 Copy operations use `cp`-like semantics:
 

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -197,6 +197,9 @@ func applyCopyOperation(ctx context.Context,
 	}
 
 	if len(matches) == 0 {
+		if op.Optional {
+			return nil
+		}
 		return fmt.Errorf("no files match pattern '%s' in source '%s'", srcPattern, srcAlias)
 	}
 
@@ -218,6 +221,9 @@ func applyCopyOperation(ctx context.Context,
 	}
 
 	if len(filteredMatches) == 0 {
+		if op.Optional {
+			return nil
+		}
 		return fmt.Errorf("all files matching pattern '%s' in source '%s' were excluded", srcPattern, srcAlias)
 	}
 
@@ -266,6 +272,9 @@ func applySingleSourceCopy(ctx context.Context,
 	srcInfo, err := srcRoot.Stat(srcPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if op.Optional {
+				return nil
+			}
 			return fmt.Errorf("source '%s' does not exist", srcPath)
 		}
 		return fmt.Errorf("failed to stat source '%s': %w", srcPath, err)

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -659,6 +659,94 @@ func TestBuildErrors(t *testing.T) {
 				return spec, sources, workspaceDir
 			},
 		},
+		{
+			name:          "optional skips when source file does not exist",
+			expectedError: "",
+			setupFunc: func(t *testing.T) (*swapi.OutputArtifact, map[string]string, string) {
+				tmpDir := t.TempDir()
+				srcDir := filepath.Join(tmpDir, "source")
+				workspaceDir := filepath.Join(tmpDir, "workspace")
+
+				setupDirs(t, srcDir, workspaceDir)
+
+				spec := &swapi.OutputArtifact{
+					Name: "optional-source-file",
+					Copy: []swapi.CopyOperation{
+						{
+							From:     "@source/test.yaml",
+							To:       "@artifact/",
+							Optional: true,
+						},
+					},
+				}
+
+				sources := map[string]string{
+					"source": srcDir,
+				}
+
+				return spec, sources, workspaceDir
+			},
+		},
+		{
+			name:          "optional skips when glob pattern matches no files",
+			expectedError: "",
+			setupFunc: func(t *testing.T) (*swapi.OutputArtifact, map[string]string, string) {
+				tmpDir := t.TempDir()
+				srcDir := filepath.Join(tmpDir, "source")
+				workspaceDir := filepath.Join(tmpDir, "workspace")
+
+				setupDirs(t, srcDir, workspaceDir)
+
+				spec := &swapi.OutputArtifact{
+					Name: "optional-glob-match",
+					Copy: []swapi.CopyOperation{
+						{
+							From:     "@source/*.yaml",
+							To:       "@artifact/",
+							Optional: true,
+						},
+					},
+				}
+
+				sources := map[string]string{
+					"source": srcDir,
+				}
+
+				return spec, sources, workspaceDir
+			},
+		},
+		{
+			name:          "optional skips when all files are excluded",
+			expectedError: "",
+			setupFunc: func(t *testing.T) (*swapi.OutputArtifact, map[string]string, string) {
+				tmpDir := t.TempDir()
+				srcDir := filepath.Join(tmpDir, "source")
+				workspaceDir := filepath.Join(tmpDir, "workspace")
+
+				setupDirs(t, srcDir, workspaceDir)
+
+				createFile(t, srcDir, "test.md", "test file")
+				createFile(t, srcDir, "other.md", "other file")
+
+				spec := &swapi.OutputArtifact{
+					Name: "optional-all-excluded",
+					Copy: []swapi.CopyOperation{
+						{
+							From:     "@source/*.md",
+							To:       "@artifact/",
+							Exclude:  []string{"*.md"},
+							Optional: true,
+						},
+					},
+				}
+
+				sources := map[string]string{
+					"source": srcDir,
+				}
+
+				return spec, sources, workspaceDir
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -667,6 +755,10 @@ func TestBuildErrors(t *testing.T) {
 			spec, sources, workspace := tt.setupFunc(t)
 
 			_, err := testBuilder.Build(context.Background(), spec, sources, "test-namespace", workspace)
+			if tt.expectedError == "" {
+				g.Expect(err).ToNot(HaveOccurred())
+				return
+			}
 			if err == nil {
 				t.Logf("Staging directory contents:")
 				walkErr := filepath.Walk(filepath.Join(workspace, spec.Name), func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
## Summary

Closes #368

Adds a per-copy-entry `optional` flag to `CopyOperation` so users can control whether a copy operation that matches no files fails or silently skips.

- Added `Optional bool` field to `CopyOperation` in `api/v1beta1/artifactgenerator_types.go`
- Builder respects the flag at three error sites: glob no-match, all-files-excluded, and non-glob path-not-found
- Regenerated CRD manifests via `make generate && make manifests`
- Updated spec docs in `docs/spec/v1beta1/artifactgenerators.md`
- Added three test cases covering each skip path

## Behavior

| Scenario | `optional: false` (default) | `optional: true` |
|---|---|---|
| Glob matches no files | Error | Silent skip |
| All matched files excluded | Error | Silent skip |
| Non-glob source path missing | Error | Silent skip |
| Missing source alias | Error (always) | Error (always) |

**Backward compatible**: `Optional` is `bool` with zero value `false`. Existing CRs without this field preserve current error behavior. The CRD change is additive.

## Changes

- `api/v1beta1/artifactgenerator_types.go` - new `Optional` field on `CopyOperation`
- `config/crd/bases/source.extensions.fluxcd.io_artifactgenerators.yaml` - regenerated CRD
- `internal/builder/builder.go` - check `op.Optional` before returning no-match errors
- `internal/builder/builder_test.go` - three new test cases in `TestBuildErrors`
- `docs/spec/v1beta1/artifactgenerators.md` - documented `optional` in Copy Operations section

## Test plan

- [x] `go test ./internal/builder/ -run TestBuild -count=1` passes (all existing + new tests)
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [x] `make test` (full suite, requires network for CRD fetch)